### PR TITLE
Bash from $PATH

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 npm run start


### PR DESCRIPTION
Search `bash` in `$PATH` and then start with the first one that can be found, rather than `bash` from `/bin` which by design of most package managers if often not the most up to date.